### PR TITLE
Changed return type of `cosmic_timestamp` in `cosmic-hyperspace from …

### DIFF
--- a/rust/cosmic/cosmic-hyperspace/src/lib.rs
+++ b/rust/cosmic/cosmic-hyperspace/src/lib.rs
@@ -12,6 +12,7 @@ extern crate lazy_static;
 extern crate strum_macros;
 
 extern crate inflector;
+use cosmic_space::wasm::Timestamp;
 use inflector::Inflector;
 
 use std::cmp::Ordering;
@@ -79,8 +80,8 @@ pub extern "C" fn cosmic_uuid() -> String {
 }
 
 #[no_mangle]
-pub extern "C" fn cosmic_timestamp() -> DateTime<Utc> {
-    Utc::now()
+pub extern "C" fn cosmic_timestamp() -> Timestamp {
+    Timestamp::new(Utc::now().timestamp_millis())
 }
 
 #[async_trait]


### PR DESCRIPTION
…`DateTime<Utc>` to `Timestamp`

I noticed that `cosmic_uuid` has varying return types also; `String` and `loc::Uuid`. Not sure if I've triggered that yet in runtime, but I suspect that might also cause a segfault at some point.

If you want, I can change all of those to `loc::Uuid` in a second commit.